### PR TITLE
Resolve deprecations for 0.206.0

### DIFF
--- a/lib/base-command.coffee
+++ b/lib/base-command.coffee
@@ -13,11 +13,11 @@ class BaseCommand
     writeAtEnd: (text) ->
         content = @getEditorContents()
         last = content.lastIndexOf('}')
-        editor = Workspace.getActiveEditor()
+        editor = Workspace.getActiveTextEditor()
 
         editor.setText ([content.slice(0, last), "\n"+text, content.slice(last)].join(''))
 
     getEditorContents: ->
-        editor = Workspace.getActiveEditor()
+        editor = Workspace.getActiveTextEditor()
 
         return editor.getText()

--- a/lib/base-command.coffee
+++ b/lib/base-command.coffee
@@ -13,11 +13,11 @@ class BaseCommand
     writeAtEnd: (text) ->
         content = @getEditorContents()
         last = content.lastIndexOf('}')
-        editor = Workspace.getActiveTextEditor()
+        editor = atom.workspace.getActiveTextEditor()
 
         editor.setText ([content.slice(0, last), "\n"+text, content.slice(last)].join(''))
 
     getEditorContents: ->
-        editor = Workspace.getActiveTextEditor()
+        editor = atom.workspace.getActiveTextEditor()
 
         return editor.getText()

--- a/lib/php-getters-setters.coffee
+++ b/lib/php-getters-setters.coffee
@@ -127,7 +127,7 @@ module.exports =
         return varsToProcess
 
     allGettersSetter: (variables) ->
-        editor = Workspace.getActiveTextEditor()
+        editor = atom.workspace.getActiveTextEditor()
         unless editor.getGrammar().scopeName is 'text.html.php' or editor.getGrammar().scopeName is 'source.php'
             alert ('this is not a PHP file')
             return

--- a/lib/php-getters-setters.coffee
+++ b/lib/php-getters-setters.coffee
@@ -127,7 +127,7 @@ module.exports =
         return varsToProcess
 
     allGettersSetter: (variables) ->
-        editor = Workspace.getActiveEditor()
+        editor = Workspace.getActiveTextEditor()
         unless editor.getGrammar().scopeName is 'text.html.php' or editor.getGrammar().scopeName is 'source.php'
             alert ('this is not a PHP file')
             return


### PR DESCRIPTION
Hello,

The plugin is disabled in 0.206.0 because of this deprecations : 

```
Call ::getActiveTextEditor instead

Workspace.getActiveEditor - /Applications/Atom.app/Contents/Resources/app.asar/src/workspace.js:1022:12
BaseCommand.getEditorContents - /Users/aanceau/.atom/packages/php-getters-setters/lib/base-command.coffee:21:32
Object.parse - /Users/aanceau/.atom/packages/php-getters-setters/lib/php-getters-setters.coffee:71:29
Object.allGettersSetter - /Users/aanceau/.atom/packages/php-getters-setters/lib/php-getters-setters.coffee:135:16
atom-workspace.atom.commands.add.php-getters-setters:allGettersSetter - /Users/aanceau/.atom/packages/php-getters-setters/lib/php-getters-setters.coffee:58:52
CommandRegistry.module.exports.CommandRegistry.handleCommandEvent - /Applications/Atom.app/Contents/Resources/app.asar/src/command-registry.js:238:29
```


```
Call ::getActiveTextEditor instead

Workspace.getActiveEditor - /Applications/Atom.app/Contents/Resources/app.asar/src/workspace.js:1022:12
Object.allGettersSetter - /Users/aanceau/.atom/packages/php-getters-setters/lib/php-getters-setters.coffee:130:32
atom-workspace.atom.commands.add.php-getters-setters:allGettersSetter - /Users/aanceau/.atom/packages/php-getters-setters/lib/php-getters-setters.coffee:58:52
CommandRegistry.module.exports.CommandRegistry.handleCommandEvent - /Applications/Atom.app/Contents/Resources/app.asar/src/command-registry.js:238:29
<unknown> - /Applications/Atom.app/Contents/Resources/app.asar/src/command-registry.js:3:61
CommandPaletteView.confirmed - /Applications/Atom.app/Contents/Resources/app.asar/node_modules/command-palette/lib/command-palette-view.js:159:32
```


```
Call ::getActiveTextEditor instead

Workspace.getActiveEditor - /Applications/Atom.app/Contents/Resources/app.asar/src/workspace.js:1022:12
BaseCommand.writeAtEnd - /Users/aanceau/.atom/packages/php-getters-setters/lib/base-command.coffee:16:32
Object.allGettersSetter - /Users/aanceau/.atom/packages/php-getters-setters/lib/php-getters-setters.coffee:154:11
atom-workspace.atom.commands.add.php-getters-setters:allGettersSetter - /Users/aanceau/.atom/packages/php-getters-setters/lib/php-getters-setters.coffee:58:52
CommandRegistry.module.exports.CommandRegistry.handleCommandEvent - /Applications/Atom.app/Contents/Resources/app.asar/src/command-registry.js:238:29
<unknown> - /Applications/Atom.app/Contents/Resources/app.asar/src/command-registry.js:3:61
```

Here is the fix :)

Thank you for your plugin !