### PR TITLE
Add "$" in @param annotation

### DIFF
--- a/lib/php-getters-setters.coffee
+++ b/lib/php-getters-setters.coffee
@@ -41,7 +41,7 @@ module.exports =
 \ \ \ \ /** \n
 \ \ \ \ * Set the value of %description% \n
 \ \ \ \ * \n
-\ \ \ \ * @param %type% %variable%\n
+\ \ \ \ * @param %type% $%variable%\n
 \ \ \ \ * \n
 \ \ \ \ * @return self\n
 \ \ \ \ */\n


### PR DESCRIPTION
Hello,

In order to follow the PHPdoc, this PR adds a `$` before `%variable%` in the default template ('cause in my opinion, the default template should follow the PHPdoc)

Thank you for this plugin :+1: 
Peekmo
