### PR TITLE
why are we removing all the spaces and adding backslashes?

### DIFF
--- a/lib/template-editor.view.coffee
+++ b/lib/template-editor.view.coffee
@@ -41,9 +41,6 @@ class TemplateEditorView extends View
 
     sanitizeTemplate: (template) =>
         return template
-                    .replace(/[^\S\r\n]+$/gm, '')
-                    .replace(/\ /g, "\\ ")
-                    # .replace(/\n/g, "\\n")
 
     save: ->
         getterTemplate = @sanitizeTemplate(@find('#txtGetter').val())


### PR DESCRIPTION
I cannot use this package without \\ getting put everywhere. Why is this sanitization step even necessary and what is it supposed to do?